### PR TITLE
Unify date format

### DIFF
--- a/app/views/partials/theme/simple/activities/feed_unit/header.liquid
+++ b/app/views/partials/theme/simple/activities/feed_unit/header.liquid
@@ -47,7 +47,7 @@
 			endcase
 			%}
 
-			<time datetime="{{ date }}" class="block mt-1 text-sm text-gray-500">{{ date | localize: 'long' }}</p>
+			<time datetime="{{ date }}" class="block mt-1 text-sm text-gray-500">{{ date | l: 'long' }}</p>
 		</p>
 	</div>
 </div>

--- a/app/views/partials/theme/simple/admin/index.liquid
+++ b/app/views/partials/theme/simple/admin/index.liquid
@@ -12,7 +12,7 @@
                 {% for user in users.results %}
                   <td>{% print user.id %}</td>
                   <td>{{ user.email }}</td>
-                  <td>{% print user.created_at  %}</td>
+                  <td>{% user.created_at | l: 'long' %}</td>
                 {% endfor %}
               </tr>
             </table>

--- a/app/views/partials/theme/simple/admin/index.liquid
+++ b/app/views/partials/theme/simple/admin/index.liquid
@@ -12,7 +12,7 @@
                 {% for user in users.results %}
                   <td>{% print user.id %}</td>
                   <td>{{ user.email }}</td>
-                  <td>{% user.created_at | l: 'long' %}</td>
+                  <td>{{ user.created_at | l: 'long' }}</td>
                 {% endfor %}
               </tr>
             </table>

--- a/app/views/partials/theme/simple/admin/items/index.liquid
+++ b/app/views/partials/theme/simple/admin/items/index.liquid
@@ -23,7 +23,7 @@
 			</div>
 			<div class="lg:w-1/6 lg:pl-2">
 				<span class="lg:hidden">{{ 'app.items.attr.created_at' | t }}: </span>
-				{{ record.created_at }}
+				{{ record.created_at | l: 'long' }}
 			</div>
 		</article>
 	{% endfor %}

--- a/app/views/partials/theme/simple/admin/users/index.liquid
+++ b/app/views/partials/theme/simple/admin/users/index.liquid
@@ -13,7 +13,7 @@
     </div>
     <div class="lg:w-1/6 lg:pl-2">
       <span class="lg:hidden">{{ 'app.users.attr.created_at' | t }}</span>
-      {{ record.created_at | l }}
+      {{ record.created_at | l: 'long' }}
     </div>
     <div class="sm:flex items-end lg:items-center lg:w-3/6 lg:pl-2">
       {% if record.profile %}

--- a/app/views/partials/theme/simple/dashboard/items/index.liquid
+++ b/app/views/partials/theme/simple/dashboard/items/index.liquid
@@ -37,7 +37,7 @@
             </select>
             <small> {% print item.c__status %}</small>
           </td>
-          <td class="px-4 py-2 border-b">{{ item.created_at | l }}</td>
+          <td class="px-4 py-2 border-b">{{ item.created_at | l: 'long' }}</td>
           <!--
           <td class="px-4 py-2 border-b">
             {{ item.status.name | default: 'missing-state-invalid-order' | t }}

--- a/app/views/partials/theme/simple/dashboard/orders/index.liquid
+++ b/app/views/partials/theme/simple/dashboard/orders/index.liquid
@@ -22,7 +22,7 @@
         <div class="lg:pl-2 lg:py-4 lg:table-cell lg:border-t">
           <span class="lg:hidden">{{ 'app.created_at' | t }}: </span>
           <a href="{{ order_url }}">
-            {{ order.created_at | l }}
+            {{ order.created_at | l: 'long' }}
           </a>
         </div>
 

--- a/app/views/partials/theme/simple/statuses/index.liquid
+++ b/app/views/partials/theme/simple/statuses/index.liquid
@@ -38,7 +38,7 @@
               </td>
               <td class="px-6 py-4 border-b border-grey-light">
                 <a href="/statuses/show/{{ status.id }}">
-                  {{ status.created_at }}
+                  {{ status.created_at | l: 'long' }}
                 </a>
               </td>
               <td class="px-6 py-4 border-b border-grey-light">

--- a/modules/chat/public/views/partials/inbox/conversation.liquid
+++ b/modules/chat/public/views/partials/inbox/conversation.liquid
@@ -37,7 +37,7 @@
 				</div>
 
 				<p class="text-gray-500 mt-1 text-sm">
-					{{ conversation.last_message.timestamp | localize: 'long' }}
+					{{ conversation.last_message.timestamp | l: 'long' }}
 				</p>
 
 			</div>

--- a/modules/chat/public/views/partials/inbox/message.liquid
+++ b/modules/chat/public/views/partials/inbox/message.liquid
@@ -1,6 +1,6 @@
 <li class="flex mb-2 break-words {{ justify }}">
 	<div class="max-w-full rounded py-2 px-3 {{ bg_color }}">
 		<p class="text-sm mt-1"> {{ message["message"]  }} </p>
-		<p class="text-right text-xs text-gray-500 mt-1"> {{ message["timestamp"] | localize: 'short' }} </p>
+		<p class="text-right text-xs text-gray-500 mt-1"> {{ message["timestamp"] | l: 'short' }} </p>
 	</div>
 </li>


### PR DESCRIPTION
https://trello.com/c/JkTCu1ii/13-unify-date-format

I kept format `compact` in

- app/views/partials/theme/simple/posts/card.liquid
- app/views/partials/theme/simple/posts/summary.liquid