### PR TITLE
Questions: allow only 5 tags for one question

### DIFF
--- a/app/views/partials/lib/commands/posts/create/check.liquid
+++ b/app/views/partials/lib/commands/posts/create/check.liquid
@@ -6,6 +6,7 @@
   function c = 'lib/validations/length', c: c, object: object, field_name: 'title', minimum: 3
   function c = 'lib/validations/presence', c: c, object: object, field_name: 'body'
   function c = 'lib/validations/length', c: c, object: object, field_name: 'body', minimum: 3
+  function c = 'lib/validations/length', c: c, object: object, field_name: 'tags', maximum: 5
 
   hash_assign object['valid'] = c.valid
   hash_assign object['errors'] = c.errors

--- a/app/views/partials/lib/commands/posts/update/check.liquid
+++ b/app/views/partials/lib/commands/posts/update/check.liquid
@@ -2,6 +2,7 @@
   assign c = '{ "errors": {}, "valid": true }' | parse_json
 
   function c = 'lib/validations/presence', c: c, object: object, field_name: 'id'
+  function c = 'lib/validations/length', c: c, object: object, field_name: 'tags', maximum: 5
 
   hash_assign object['valid'] = c.valid
   hash_assign object['errors'] = c.errors

--- a/app/views/partials/lib/validations/length.liquid
+++ b/app/views/partials/lib/validations/length.liquid
@@ -10,17 +10,17 @@
   assign size = object[field_name].size
   if minimum != null and size < minimum
     assign message = 'app.errors.length.minimum' | t: count: minimum, value: size
-    include 'lib/register_error', contract: c, field_name: field_name, key:
+    include 'lib/register_error', contract: c, field_name: field_name, message: message
   endif
 
   if maximum != null and size > maximum
     assign message = 'app.errors.length.maximum' | t: count: maximum, value: size
-    include 'lib/register_error', contract: c, field_name: field_name, key: 'app.errors.length.maximum'
+    include 'lib/register_error', contract: c, field_name: field_name, message: message
   endif
 
   if is != null and size != is
     assign message = 'app.errors.length.is' | t: count: is, value: size
-    include 'lib/register_error', contract: c, field_name: field_name, key: 'app.errors.length.is'
+    include 'lib/register_error', contract: c, field_name: field_name, message: message
   endif
 
   return c

--- a/app/views/partials/test/commands/posts/create_test.liquid
+++ b/app/views/partials/test/commands/posts/create_test.liquid
@@ -11,3 +11,11 @@
   function contract = 'test/assertions/presence', contract: contract, object: object, field_name: 'id'
   function contract = 'test/assertions/valid_object', contract: contract, object: object, field_name: 'id'
 %}
+
+{% liquid
+  assign params = '{"title": "ooo oo", "body":"foo ooo ooo ooo", "uuid": "12345", "tags": "foo,bar,zoo,moo,boo,uuu"}' | parse_json
+  function object = 'lib/commands/posts/create', object: params, current_profile: profile
+
+  function contract = 'test/assertions/not_valid_object', contract: contract, object: object, field_name: 'id'
+  function contract = 'test/assertions/equal', contract: contract, field_name: 'errors', given: object.errors.tags[0], expected: "is too long (maximum is 5 characters)"
+%}


### PR DESCRIPTION
Fixes: https://trello.com/c/iduQkOtp/108-limit-the-max-tag-numer-to-5