### PR TITLE
potential-fix-for-uuid-not-found-error

### DIFF
--- a/app/views/pages/dashboard/posts/vote.liquid
+++ b/app/views/pages/dashboard/posts/vote.liquid
@@ -10,7 +10,7 @@ method: post
   function object = 'lib/commands/posts/vote', object: context.params.post, current_profile: current_profile, post: post
 
   if object.valid
-    include 'lib/commands/events/create', type: 'post_voted', actor_id: current_profile.id, object_id: object.id
+    include 'lib/commands/events/create', type: 'post_voted', actor_id: current_profile.id, object_id: object.id, delay: 2
   else
     assign errors = object.errors.base | join: ', '
     include 'lib/flash/publish', error: errors


### PR DESCRIPTION
this might be related to multiple transactions within one graphql query

```
{ name: "upvote_profile_ids", array_append: $upvote_profile_id_append }
{ name: "upvote_profile_ids", array_remove: $upvote_profile_id_remove }
```