### PR TITLE
Feed: do not show extra profile image when I posted comment

### DIFF
--- a/app/views/partials/theme/simple/activities/feed_unit.liquid
+++ b/app/views/partials/theme/simple/activities/feed_unit.liquid
@@ -15,7 +15,7 @@
     <div class="mt-2">
       <img class="object-cover rounded-lg w-9" src="{{ payload.object.photos.first.url.versions.small }}" alt="{{ payload.object.name }}">
     </div>
-  {% elsif payload.target.photos.size > 0 %}
+  {% elsif payload.target.photos.size > 0 and payload.type != 'comment_created' %}
     <div class="mt-2">
       <img class="object-cover rounded-lg w-9" src="{{ payload.target.photos.first.url.versions.small }}" alt="{{ payload.target.name }}">
     </div>


### PR DESCRIPTION
https://trello.com/c/ksGEvyuP/254-your-avatar-image-is-included-to-any-post-in-group-except-if-you-upload-some-image